### PR TITLE
Refactor backend as installable package

### DIFF
--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,1 +1,7 @@
- 
+"""Backend package initialization."""
+
+__all__ = ["crud", "database", "models", "schemas"]
+
+# Package version
+__version__ = "1.0.0"
+

--- a/backend/create_db.py
+++ b/backend/create_db.py
@@ -1,5 +1,5 @@
-from database import engine
-from models import Base
+from backend.database import engine
+from backend.models import Base
 
 def create_database():
     """

--- a/backend/create_document.py
+++ b/backend/create_document.py
@@ -1,6 +1,5 @@
-from database import SessionLocal
-import crud
-import schemas
+from backend.database import SessionLocal
+from backend import crud, schemas
 
 def create_test_document():
     """

--- a/backend/crud.py
+++ b/backend/crud.py
@@ -1,6 +1,5 @@
 from sqlalchemy.orm import Session, joinedload
-import models
-import schemas
+from backend import models, schemas
 
 # --- Document CRUD ---
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -3,10 +3,8 @@ from sqlalchemy.orm import Session
 from fastapi.middleware.cors import CORSMiddleware
 import json
 
-import crud
-import models
-import schemas
-from database import SessionLocal, engine
+from backend import crud, models, schemas
+from backend.database import SessionLocal, engine
 
 # This will now check if the tables exist before trying to create them.
 models.Base.metadata.create_all(bind=engine, checkfirst=True)

--- a/backend/models.py
+++ b/backend/models.py
@@ -1,7 +1,7 @@
 from sqlalchemy import Column, Integer, String, Text, DateTime, Float, ForeignKey
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
-import database
+from backend import database
 
 Base = database.Base
 

--- a/backend/parse_vision_json.py
+++ b/backend/parse_vision_json.py
@@ -1,8 +1,7 @@
 import json
 import os
-from database import SessionLocal
-import crud
-import schemas
+from backend.database import SessionLocal
+from backend import crud, schemas
 
 # The ID of the document we want to import lines for.
 DOCUMENT_ID = 1

--- a/backend/populate_line_numbers.py
+++ b/backend/populate_line_numbers.py
@@ -1,9 +1,7 @@
 import os
-import sys
+
 from sqlalchemy.orm import Session
 
-# Add the parent directory to the sys.path to allow for package imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from backend import crud, schemas
 from backend.database import SessionLocal, engine

--- a/backend/reimport_lines.py
+++ b/backend/reimport_lines.py
@@ -1,9 +1,8 @@
 import os
 from typing import List
-from database import SessionLocal
-import crud
-import schemas
-from models import OcrResult
+from backend.database import SessionLocal
+from backend import crud, schemas
+from backend.models import OcrResult
 
 # The ID of the document we are processing.
 DOCUMENT_ID = 1

--- a/backend/run_all_migrations.py
+++ b/backend/run_all_migrations.py
@@ -1,9 +1,6 @@
 import json
 import os
-import sys
 
-# Add the parent directory to allow for package imports
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 
 from backend import crud, schemas
 from backend.database import SessionLocal

--- a/backend/universal_parser.py
+++ b/backend/universal_parser.py
@@ -1,8 +1,7 @@
 import json
 import os
-from database import SessionLocal
-import crud
-import schemas
+from backend.database import SessionLocal
+from backend import crud, schemas
 
 def parse_document_ai_and_import():
     """


### PR DESCRIPTION
## Summary
- turn `backend` into a real Python package exposing `__version__`
- use absolute imports like `from backend import crud, database`
- remove custom `sys.path` tweaks
- update scripts so they run with `python -m backend.<script>`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c178e9e748322bbc3d9165e1310f2