### PR TITLE
Refactor Document AI parsing logic

### DIFF
--- a/backend/parsers/document_ai.py
+++ b/backend/parsers/document_ai.py
@@ -1,0 +1,83 @@
+import json
+from typing import Iterable, List
+from sqlalchemy.orm import Session
+
+from backend import crud, schemas
+
+
+def load_json(json_path: str) -> dict:
+    """Load a Document AI JSON file from ``json_path``."""
+    with open(json_path, 'r', encoding='utf-8') as f:
+        return json.load(f)
+
+
+def create_ocr_results(db: Session, doc_ai_data: dict, document_id: int) -> int:
+    """Parse Document AI JSON and create ``OcrResult`` records.
+
+    Returns the number of created records.
+    """
+    created = 0
+    for page in doc_ai_data.get('pages', []):
+        page_width = page.get('dimension', {}).get('width')
+        page_height = page.get('dimension', {}).get('height')
+        if not page_width or not page_height:
+            continue
+
+        for line in page.get('lines', []):
+            try:
+                text_anchor = line.get('layout', {}).get('textAnchor', {})
+                text_segments = text_anchor.get('textSegments', [{}])
+                start_index = int(text_segments[0].get('startIndex', 0))
+                end_index = int(text_segments[0].get('endIndex', 0))
+                text = (
+                    doc_ai_data['text'][start_index:end_index]
+                    .strip()
+                    .replace('\n', ' ')
+                )
+                vertices = line.get('layout', {}).get('boundingPoly', {}).get('normalizedVertices', [])
+                if not vertices or not text:
+                    continue
+                x_coords = [v.get('x', 0) * page_width for v in vertices]
+                y_coords = [v.get('y', 0) * page_height for v in vertices]
+                min_x, max_x = min(x_coords), max(x_coords)
+                min_y, max_y = min(y_coords), max(y_coords)
+                schema = schemas.OcrResultCreate(
+                    page=page.get('pageNumber', 1),
+                    text=text,
+                    x_coord=min_x,
+                    y_coord=min_y,
+                    width=max_x - min_x,
+                    height=max_y - min_y,
+                )
+                crud.create_ocr_result(db=db, ocr_result=schema, document_id=document_id)
+                created += 1
+            except (KeyError, IndexError, TypeError):
+                continue
+    return created
+
+
+def create_line_numbers(
+    db: Session,
+    ground_truth_lines: Iterable[str],
+    document_id: int,
+) -> int:
+    """Create ``LineNumber`` records for ``ground_truth_lines`` using existing OCR results."""
+    target_set = {line.strip() for line in ground_truth_lines if line.strip()}
+    if not target_set:
+        return 0
+
+    ocr_results = crud.get_ocr_results(db=db, document_id=document_id)
+    created = 0
+    for result in ocr_results:
+        if result.text in target_set:
+            line_schema = schemas.LineNumberCreate(
+                page=result.page,
+                text=result.text,
+                x_coord=result.x_coord,
+                y_coord=result.y_coord,
+                width=result.width,
+                height=result.height,
+            )
+            crud.create_line_number(db=db, line_number=line_schema, document_id=document_id)
+            created += 1
+    return created

--- a/backend/reimport_lines.py
+++ b/backend/reimport_lines.py
@@ -1,41 +1,13 @@
 import os
-from typing import List
 from backend.database import SessionLocal
-from backend import crud, schemas
-from backend.models import OcrResult
+from backend import crud
+from backend.parsers import document_ai
 
 # The ID of the document we are processing.
 DOCUMENT_ID = 1
 # Path to the text file containing the target line numbers.
 TARGET_LINES_PATH = os.path.join(os.path.dirname(__file__), '..', 'data', 'extracted_piping_lines.txt')
 
-
-def filter_line_numbers(ocr_results: List[OcrResult], target_texts: List[str]) -> List[OcrResult]:
-    """
-    Filters OCR results to find those that exactly match the target texts.
-
-    In the future, this function can be modified to use regular expressions
-    or more complex matching logic.
-
-    Args:
-        ocr_results: A list of OcrResult objects from the database.
-        target_texts: A list of strings to search for.
-
-    Returns:
-        A list of matching OcrResult objects.
-    """
-    print(f"Filtering {len(ocr_results)} OCR results against {len(target_texts)} target texts.")
-    
-    # Create a set for faster lookups
-    target_set = set(t.strip() for t in target_texts if t.strip())
-    
-    found_results = []
-    for result in ocr_results:
-        if result.text and result.text.strip() in target_set:
-            found_results.append(result)
-            
-    print(f"Found {len(found_results)} matching line numbers.")
-    return found_results
 
 
 def reimport_lines_from_db():
@@ -65,30 +37,9 @@ def reimport_lines_from_db():
             print("No target line numbers found in the file.")
             return
 
-        # 3. Get all OCR results from the database for the document
-        print("Fetching all OCR results from the database...")
-        all_ocr_results = crud.get_all_ocr_results_for_document(db=db, document_id=DOCUMENT_ID)
-        if not all_ocr_results:
-            print("No OCR results found in the database for this document.")
-            return
-
-        # 4. Filter the results
-        matched_results = filter_line_numbers(all_ocr_results, target_texts)
-
-        # 5. Create new LineNumber entries from the filtered results
-        for ocr_result in matched_results:
-            line_create_schema = schemas.LineNumberCreate(
-                page=ocr_result.page,
-                text=ocr_result.text,
-                x_coord=ocr_result.x_coord,
-                y_coord=ocr_result.y_coord,
-                width=ocr_result.width,
-                height=ocr_result.height,
-                status="pending"  # Or copy from ocr_result if needed
-            )
-            crud.create_line_number(db=db, line_number=line_create_schema, document_id=DOCUMENT_ID)
-
-        print(f"Successfully created {len(matched_results)} new line number entries.")
+        # 3. Create line numbers from existing OCR results
+        created = document_ai.create_line_numbers(db, target_texts, DOCUMENT_ID)
+        print(f"Successfully created {created} new line number entries.")
 
     except Exception as e:
         print(f"An error occurred during re-import: {e}")

--- a/backend/run_all_migrations.py
+++ b/backend/run_all_migrations.py
@@ -1,9 +1,9 @@
 import json
 import os
 
-
 from backend import crud, schemas
 from backend.database import SessionLocal
+from backend.parsers import document_ai
 
 def parse_and_populate_all():
     """
@@ -35,11 +35,10 @@ def parse_and_populate_all():
         crud.delete_line_numbers_by_document(db=db, document_id=DOCUMENT_ID)
         print("Existing data cleared.")
 
-        # --- Step 3: Load the Document AI JSON ---
+        # --- Step 3: Load the Document AI JSON and populate OCR results ---
         print(f"Loading Document AI JSON from {json_path}...")
         try:
-            with open(json_path, 'r', encoding='utf-8') as f:
-                doc_ai_data = json.load(f)
+            doc_ai_data = document_ai.load_json(json_path)
         except FileNotFoundError:
             print(f"FATAL: JSON file not found at {json_path}")
             return
@@ -48,67 +47,16 @@ def parse_and_populate_all():
             return
         print("JSON loaded successfully.")
 
-        # --- Step 4: Parse JSON and Populate ocr_results table ---
-        print("Building a map of all text segments from the document...")
-        ocr_results_to_create = []
-        for page in doc_ai_data.get('pages', []):
-            page_width = page.get('dimension', {}).get('width')
-            page_height = page.get('dimension', {}).get('height')
-            if not page_width or not page_height:
-                continue
-
-            for line in page.get('lines', []):
-                try:
-                    text_anchor = line.get('layout', {}).get('textAnchor', {})
-                    text_segments = text_anchor.get('textSegments', [{}])
-                    start_index = int(text_segments[0].get('startIndex', 0))
-                    end_index = int(text_segments[0].get('endIndex', 0))
-                    line_text = doc_ai_data['text'][start_index:end_index].strip().replace('\\n', ' ').replace('\n', ' ')
-                    
-                    vertices = line.get('layout', {}).get('boundingPoly', {}).get('normalizedVertices', [])
-                    if not vertices or not line_text:
-                        continue
-                        
-                    x_coords = [v.get('x', 0) * page_width for v in vertices]
-                    y_coords = [v.get('y', 0) * page_height for v in vertices]
-                    min_x, max_x = min(x_coords), max(x_coords)
-                    min_y, max_y = min(y_coords), max(y_coords)
-                    
-                    ocr_results_to_create.append(schemas.OcrResultCreate(
-                        page=page.get('pageNumber', 1),
-                        text=line_text,
-                        x_coord=min_x, y_coord=min_y,
-                        width=max_x - min_x, height=max_y - min_y
-                    ))
-                except (KeyError, IndexError, TypeError):
-                    continue
-        
-        print(f"Mapped {len(ocr_results_to_create)} text segments. Populating ocr_results table...")
-        for ocr_schema in ocr_results_to_create:
-            crud.create_ocr_result(db=db, ocr_result=ocr_schema, document_id=DOCUMENT_ID)
-        print("ocr_results table populated successfully.")
+        created_count = document_ai.create_ocr_results(db, doc_ai_data, DOCUMENT_ID)
+        print(f"Populated ocr_results table with {created_count} entries.")
 
         # --- Step 5: Populate line_numbers from ground truth ---
         print("\nPopulating line_numbers table from ground truth file...")
         truth_file_path = os.path.join('output', 'extracted_piping_lines.txt')
         with open(truth_file_path, 'r') as f:
-            target_lines = {line.strip() for line in f.readlines()[4:] if line.strip()}
+            target_lines = [line.strip() for line in f.readlines()[4:] if line.strip()]
 
-        all_ocr_results = crud.get_ocr_results(db=db, document_id=DOCUMENT_ID)
-        
-        lines_created_count = 0
-        for ocr_result in all_ocr_results:
-            if ocr_result.text in target_lines:
-                line_schema = schemas.LineNumberCreate(
-                    text=ocr_result.text,
-                    x_coord=ocr_result.x_coord,
-                    y_coord=ocr_result.y_coord,
-                    width=ocr_result.width,
-                    height=ocr_result.height,
-                    page=ocr_result.page
-                )
-                crud.create_line_number(db=db, line_number=line_schema, document_id=DOCUMENT_ID)
-                lines_created_count += 1
+        lines_created_count = document_ai.create_line_numbers(db, target_lines, DOCUMENT_ID)
         print(f"Successfully created {lines_created_count} entries in line_numbers table.")
 
         print("\n--- Import Complete ---")

--- a/backend/universal_parser.py
+++ b/backend/universal_parser.py
@@ -1,7 +1,8 @@
-import json
 import os
+import json
 from backend.database import SessionLocal
 from backend import crud, schemas
+from backend.parsers import document_ai
 
 def parse_document_ai_and_import():
     """
@@ -35,11 +36,10 @@ def parse_document_ai_and_import():
         # crud.delete_line_numbers_by_document(db=db, document_id=DOCUMENT_ID) # Old code
         print("Existing OCR results deleted successfully.")
 
-        # 3. Load the Document AI JSON
+        # 3. Load the Document AI JSON and import OCR results
         print(f"Loading Document AI JSON from {json_path}...")
         try:
-            with open(json_path, 'r', encoding='utf-8') as f:
-                doc_ai_data = json.load(f)
+            doc_ai_data = document_ai.load_json(json_path)
         except FileNotFoundError:
             print(f"Error: JSON file not found at {json_path}")
             return
@@ -48,78 +48,11 @@ def parse_document_ai_and_import():
             return
         print("JSON loaded successfully.")
 
-        # 4. Build a map of all text segments and their coordinates
-        print("Building a map of all text segments from the document...")
-        text_map = {}
-        for page_index, page in enumerate(doc_ai_data.get('pages', [])):
-            page_width = page.get('dimension', {}).get('width')
-            page_height = page.get('dimension', {}).get('height')
-            if not page_width or not page_height:
-                continue
-            for line in page.get('lines', []):
-                try:
-                    start_index = int(line.get('layout', {}).get('textAnchor', {}).get('textSegments', [{}])[0].get('startIndex', 0))
-                    end_index = int(line.get('layout', {}).get('textAnchor', {}).get('textSegments', [{}])[0].get('endIndex', 0))
-                    line_text_content = doc_ai_data['text'][start_index:end_index].strip()
-                except (KeyError, IndexError, TypeError):
-                    continue
-                normalized_text = line_text_content.replace('\\"', '"')
-                vertices = line.get('layout', {}).get('boundingPoly', {}).get('normalizedVertices', [])
-                if not vertices or not normalized_text:
-                    continue
-                x_coords = [v.get('x', 0) * page_width for v in vertices]
-                y_coords = [v.get('y', 0) * page_height for v in vertices]
-                min_x, max_x = min(x_coords), max(x_coords)
-                min_y, max_y = min(y_coords), max(y_coords)
-                text_map[normalized_text] = {
-                    "page": page_index + 1, "x_coord": min_x, "y_coord": min_y,
-                    "width": max_x - min_x, "height": max_y - min_y
-                }
-        print(f"Mapped {len(text_map)} unique text segments.")
-
-        # 5. Import all found lines to the ocr_results table
-        print("Importing all found lines to ocr_results table...")
-        unique_lines = set()
-        new_results_count = 0
-        
-        for text_key, coords in text_map.items():
-            # Create a unique identifier for the line based on its text and coordinates
-            line_tuple = (
-                text_key,
-                coords["x_coord"],
-                coords["y_coord"],
-                coords["width"],
-                coords["height"]
-            )
-            
-            if line_tuple not in unique_lines:
-                unique_lines.add(line_tuple)
-                
-                # Use OcrResultCreate schema
-                ocr_result_create_schema = schemas.OcrResultCreate(
-                    page=coords["page"],
-                    text=text_key,
-                    x_coord=coords["x_coord"],
-                    y_coord=coords["y_coord"],
-                    width=coords["width"],
-                    height=coords["height"]
-                )
-                crud.create_ocr_result(db=db, ocr_result=ocr_result_create_schema, document_id=DOCUMENT_ID)
-
-                # Old code for LineNumber
-                # line_create_schema = schemas.LineNumberCreate(
-                #     page=coords["page"],
-                #     text=text_key,
-                #     x_coord=coords["x_coord"],
-                #     y_coord=coords["y_coord"],
-                #     width=coords["width"],
-                #     height=coords["height"]
-                # )
-                # crud.create_line_number(db=db, line_number=line_create_schema, document_id=DOCUMENT_ID)
-                
-                new_results_count += 1
-
-        print(f"Successfully added {new_results_count} unique OCR results to document ID: {DOCUMENT_ID}.")
+        print("Importing OCR results into the database...")
+        new_results_count = document_ai.create_ocr_results(db, doc_ai_data, DOCUMENT_ID)
+        print(
+            f"Successfully added {new_results_count} unique OCR results to document ID: {DOCUMENT_ID}."
+        )
 
     except Exception as e:
         print(f"An error occurred during import: {e}")
@@ -158,24 +91,8 @@ def parse_line_numbers():
             return
         print(f"Found {len(target_lines)} target line numbers to process.")
 
-        # 3. Find matching OCR results and create line_numbers
-        lines_created = 0
-        for line_text in target_lines:
-            ocr_result = crud.get_ocr_result_by_text(db, text=line_text, document_id=DOCUMENT_ID)
-            if ocr_result:
-                line_create_schema = schemas.LineNumberCreate(
-                    text=ocr_result.text,
-                    x_coord=ocr_result.x_coord,
-                    y_coord=ocr_result.y_coord,
-                    width=ocr_result.width,
-                    height=ocr_result.height,
-                    status="pending"
-                )
-                crud.create_line_number(db=db, line_number=line_create_schema, document_id=DOCUMENT_ID)
-                lines_created += 1
-            else:
-                print(f"Warning: Line number '{line_text}' not found in ocr_results for document ID {DOCUMENT_ID}.")
-        
+        # 3. Create line numbers from OCR results
+        lines_created = document_ai.create_line_numbers(db, target_lines, DOCUMENT_ID)
         print(f"Successfully created {lines_created} entries in the line_numbers table.")
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- implement `parsers/document_ai.py` with helpers to load JSON and store OCR/line number records
- update parsers and utilities to reuse the new module

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_685c2ae8d1c08322a78f56def572fe44