### PR TITLE
Add environment-based configuration support

### DIFF
--- a/backend/config.py
+++ b/backend/config.py
@@ -1,0 +1,19 @@
+from functools import lru_cache
+from pydantic import BaseSettings
+import os
+
+
+class Settings(BaseSettings):
+    database_url: str = "sqlite:///./pid_visualizer.db"
+    api_base_url: str = "http://localhost:8000"
+    data_dir: str = "./data"
+    debug: bool = False
+    log_level: str = "INFO"
+
+    class Config:
+        env_file = os.path.join(os.path.dirname(os.path.dirname(__file__)), ".env")
+
+
+@lru_cache()
+def get_settings() -> Settings:
+    return Settings()

--- a/backend/database.py
+++ b/backend/database.py
@@ -1,18 +1,16 @@
 from sqlalchemy import create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import sessionmaker
-import os
 
-# Build an absolute path to the database file in the project root directory
-# This ensures that both scripts and the server use the same database file
-PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-DATABASE_NAME = "pid_visualizer.db"
-SQLALCHEMY_DATABASE_URL = f"sqlite:///{os.path.join(PROJECT_ROOT, DATABASE_NAME)}"
+from .config import get_settings
 
-
-engine = create_engine(
-    SQLALCHEMY_DATABASE_URL, connect_args={"check_same_thread": False}
+settings = get_settings()
+SQLALCHEMY_DATABASE_URL = settings.database_url
+connect_args = (
+    {"check_same_thread": False} if SQLALCHEMY_DATABASE_URL.startswith("sqlite") else {}
 )
+
+engine = create_engine(SQLALCHEMY_DATABASE_URL, connect_args=connect_args)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-Base = declarative_base() 
+Base = declarative_base()

--- a/backend/parsers/import_lines.py
+++ b/backend/parsers/import_lines.py
@@ -2,55 +2,76 @@ import json
 import requests
 import os
 
+from backend.config import get_settings
+
+settings = get_settings()
+
+
 def parse_and_import():
     """
     Parses a Google Document AI JSON file to find coordinates for specific line numbers
     and imports them into the database via the FastAPI backend.
     """
     # --- Configuration ---
-    project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    json_path = os.path.join(project_root, 'output', 'test_pid.pdf_processed.json')
-    lines_path = os.path.join(project_root, 'output', 'extracted_piping_lines.txt')
-    api_url = "http://localhost:8000/documents/4/parse-json" # Document ID is 4
+    json_path = os.path.join(settings.data_dir, "test_pid.pdf_processed.json")
+    lines_path = os.path.join(settings.data_dir, "extracted_piping_lines.txt")
+    api_url = f"{settings.api_base_url}/documents/4/parse-json"  # Document ID is 4
 
     # --- 1. Read target line numbers ---
     print(f"Reading target line numbers from {lines_path}...")
-    with open(lines_path, 'r') as f:
+    with open(lines_path, "r") as f:
         target_lines = {line.strip() for line in f.readlines()[4:] if line.strip()}
     print(f"Found {len(target_lines)} target lines.")
 
     # --- 2. Load the Document AI JSON ---
     print(f"Loading Document AI JSON from {json_path}...")
-    with open(json_path, 'r', encoding='utf-8') as f:
+    with open(json_path, "r", encoding="utf-8") as f:
         doc_ai_data = json.load(f)
     print("JSON loaded successfully.")
 
     # --- 3. Build a map of all text segments and their coordinates ---
     print("Building a map of all text segments from the document...")
     text_map = {}
-    for page_index, page in enumerate(doc_ai_data.get('pages', [])):
-        page_width = page.get('dimension', {}).get('width')
-        page_height = page.get('dimension', {}).get('height')
+    for page_index, page in enumerate(doc_ai_data.get("pages", [])):
+        page_width = page.get("dimension", {}).get("width")
+        page_height = page.get("dimension", {}).get("height")
         if not page_width or not page_height:
             continue
-        for line in page.get('lines', []):
+        for line in page.get("lines", []):
             try:
-                start_index = int(line.get('layout', {}).get('textAnchor', {}).get('textSegments', [{}])[0].get('startIndex', 0))
-                end_index = int(line.get('layout', {}).get('textAnchor', {}).get('textSegments', [{}])[0].get('endIndex', 0))
-                line_text_content = doc_ai_data['text'][start_index:end_index].strip()
+                start_index = int(
+                    line.get("layout", {})
+                    .get("textAnchor", {})
+                    .get("textSegments", [{}])[0]
+                    .get("startIndex", 0)
+                )
+                end_index = int(
+                    line.get("layout", {})
+                    .get("textAnchor", {})
+                    .get("textSegments", [{}])[0]
+                    .get("endIndex", 0)
+                )
+                line_text_content = doc_ai_data["text"][start_index:end_index].strip()
             except (KeyError, IndexError, TypeError):
                 continue
             normalized_text = line_text_content.replace('\\"', '"')
-            vertices = line.get('layout', {}).get('boundingPoly', {}).get('normalizedVertices', [])
+            vertices = (
+                line.get("layout", {})
+                .get("boundingPoly", {})
+                .get("normalizedVertices", [])
+            )
             if not vertices or not normalized_text:
                 continue
-            x_coords = [v.get('x', 0) * page_width for v in vertices]
-            y_coords = [v.get('y', 0) * page_height for v in vertices]
+            x_coords = [v.get("x", 0) * page_width for v in vertices]
+            y_coords = [v.get("y", 0) * page_height for v in vertices]
             min_x, max_x = min(x_coords), max(x_coords)
             min_y, max_y = min(y_coords), max(y_coords)
             text_map[normalized_text] = {
-                "page": page_index + 1, "x_coord": min_x, "y_coord": min_y,
-                "width": max_x - min_x, "height": max_y - min_y
+                "page": page_index + 1,
+                "x_coord": min_x,
+                "y_coord": min_y,
+                "width": max_x - min_x,
+                "height": max_y - min_y,
             }
     print(f"Mapped {len(text_map)} unique text segments.")
 
@@ -62,8 +83,12 @@ def parse_and_import():
         for target in list(unmatched_targets):
             if target in text_key:
                 line_data = {
-                    "text": target, "page": coords["page"], "x_coord": coords["x_coord"],
-                    "y_coord": coords["y_coord"], "width": coords["width"], "height": coords["height"]
+                    "text": target,
+                    "page": coords["page"],
+                    "x_coord": coords["x_coord"],
+                    "y_coord": coords["y_coord"],
+                    "width": coords["width"],
+                    "height": coords["height"],
                 }
                 found_lines_data.append(line_data)
                 print(f"  - Matched '{target}' within '{text_key}'")
@@ -90,6 +115,6 @@ def parse_and_import():
         print(f"An error occurred while calling the API: {e}")
         print("Response body:", e.response.text if e.response else "N/A")
 
+
 if __name__ == "__main__":
     parse_and_import()
- 

--- a/backend/populate_db.py
+++ b/backend/populate_db.py
@@ -2,7 +2,11 @@ import requests
 import json
 import os
 
-API_BASE_URL = "http://127.0.0.1:8000"
+from backend.config import get_settings
+
+settings = get_settings()
+API_BASE_URL = settings.api_base_url
+
 
 def create_document(file_name="test_pid.pdf", pages=1):
     """Creates a document record in the database."""
@@ -13,10 +17,11 @@ def create_document(file_name="test_pid.pdf", pages=1):
         response.raise_for_status()  # Raise an exception for bad status codes
         doc_data = response.json()
         print(f"Successfully created document with ID: {doc_data['id']}")
-        return doc_data['id']
+        return doc_data["id"]
     except requests.exceptions.RequestException as e:
         print(f"Error creating document: {e}")
         return None
+
 
 def populate_ocr_results(doc_id, json_file_path):
     """Populates the ocr_results table from a JSON file."""
@@ -25,8 +30,8 @@ def populate_ocr_results(doc_id, json_file_path):
         return
 
     url = f"{API_BASE_URL}/documents/{doc_id}/parse-json"
-    
-    with open(json_file_path, 'r') as f:
+
+    with open(json_file_path, "r") as f:
         data = json.load(f)
 
     try:
@@ -36,16 +41,16 @@ def populate_ocr_results(doc_id, json_file_path):
         print(f"Response: {response.json()}")
     except requests.exceptions.RequestException as e:
         print(f"Error populating ocr_results: {e}")
-        if 'response' in locals() and e.response is not None:
+        if "response" in locals() and e.response is not None:
             print(f"Error details: {e.response.text}")
 
 
 if __name__ == "__main__":
     print("Starting database population script...")
     # The script should be run from the root directory
-    json_path = os.path.join('data', 'test_pid.pdf_processed.json')
-    
+    json_path = os.path.join(settings.data_dir, "test_pid.pdf_processed.json")
+
     document_id = create_document()
     if document_id:
         populate_ocr_results(document_id, json_path)
-    print("Script finished.") 
+    print("Script finished.")

--- a/check.js
+++ b/check.js
@@ -1,9 +1,14 @@
 const http = require('http');
+const path = require('path');
+require('dotenv').config({ path: path.join(__dirname, '.env') });
+
+const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:8000';
+const url = new URL('/doc/1', API_BASE_URL);
 
 const options = {
-  hostname: 'localhost',
-  port: 8000,
-  path: '/doc/1',
+  hostname: url.hostname,
+  port: url.port || 80,
+  path: url.pathname,
   method: 'GET'
 };
 

--- a/env.example
+++ b/env.example
@@ -2,6 +2,11 @@
 DATABASE_URL=sqlite:///./pid_visualizer.db
 # For PostgreSQL: DATABASE_URL=postgresql://username:password@localhost:5432/pid_visualizer
 
+# Base URL for backend API used by helper scripts and watchers
+API_BASE_URL=http://localhost:8000
+# Directory for PDF and JSON files
+DATA_DIR=./data
+
 # Google Cloud Vision API
 GOOGLE_APPLICATION_CREDENTIALS=./path/to/service-account-key.json
 

--- a/file-watcher/index.js
+++ b/file-watcher/index.js
@@ -2,9 +2,9 @@ const fs = require('fs').promises;
 const path = require('path');
 const chokidar = require('chokidar');
 const axios = require('axios');
-
-const dataDir = path.join(__dirname, '..', 'data');
-const API_BASE_URL = 'http://localhost:8000';
+require('dotenv').config({ path: path.join(__dirname, '..', '.env') });
+const dataDir = process.env.DATA_DIR || path.join(__dirname, '..', 'data');
+const API_BASE_URL = process.env.API_BASE_URL || 'http://localhost:8000';
 
 console.log(`Watching for file changes in ${dataDir}`);
 

--- a/file-watcher/package.json
+++ b/file-watcher/package.json
@@ -9,9 +9,10 @@
   "author": "",
   "license": "ISC",
   "description": "",
-  "dependencies": {
+    "dependencies": {
     "axios": "^1.10.0",
     "chokidar": "^4.0.3",
-    "pg": "^8.16.2"
+    "pg": "^8.16.2",
+    "dotenv": "^16.3.1"
   }
 }


### PR DESCRIPTION
## Summary
- introduce `backend/config.py` using pydantic `BaseSettings`
- load DB URL from environment in backend
- update scripts to use `API_BASE_URL` and `DATA_DIR`
- add `.env` variables for backend scripts
- make Node watcher respect env vars via `dotenv`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685c2f6bdbf08322a0b8ee5abf31e5f6