### PR TITLE
Refactor backend routes and introduce service layer

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,17 +1,13 @@
-from fastapi import Depends, FastAPI, HTTPException
-from sqlalchemy.orm import Session
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-import json
+from backend import models
+from backend.database import engine
+from backend.routers import documents, lines
 
-from backend import crud, models, schemas
-from backend.database import SessionLocal, engine
-
-# This will now check if the tables exist before trying to create them.
 models.Base.metadata.create_all(bind=engine, checkfirst=True)
 
 app = FastAPI()
 
-# Allow CORS for frontend development
 origins = [
     "http://localhost:5173",
     "http://127.0.0.1:5173",
@@ -25,58 +21,5 @@ app.add_middleware(
     allow_headers=["*"],
 )
 
-# Dependency
-def get_db():
-    db = SessionLocal()
-    try:
-        yield db
-    finally:
-        db.close()
-
-@app.post("/documents/", response_model=schemas.Document)
-def create_document(document: schemas.DocumentCreate, db: Session = Depends(get_db)):
-    return crud.create_document(db=db, document=document)
-
-@app.get("/doc/{doc_id}", response_model=schemas.Document)
-def read_document(doc_id: int, db: Session = Depends(get_db)):
-    db_document = crud.get_document(db, document_id=doc_id)
-    if db_document is None:
-        raise HTTPException(status_code=404, detail="Document not found")
-    return db_document
-
-@app.patch("/line/{line_id}", response_model=schemas.LineNumber)
-def update_line(line_id: int, text: str, status: str, db: Session = Depends(get_db)):
-    db_line_number = crud.update_line_number(db, line_number_id=line_id, text=text, status=status)
-    if db_line_number is None:
-        raise HTTPException(status_code=404, detail="LineNumber not found")
-    return db_line_number
-
-@app.post("/documents/{doc_id}/parse-json")
-def parse_json_for_document(doc_id: int, data: dict, db: Session = Depends(get_db)):
-    db_document = crud.get_document(db, document_id=doc_id)
-    if db_document is None:
-        raise HTTPException(status_code=404, detail="Document not found")
-
-    try:
-        # This endpoint now populates the OcrResult table
-        for ocr_data in data.get('line_numbers', []): # Assuming input key from OCR is still 'line_numbers'
-            ocr_result_create = schemas.OcrResultCreate(
-                page=ocr_data.get('page', 1), # Default to page 1 if not provided
-                text=ocr_data['text'],
-                x_coord=ocr_data['x_coord'],
-                y_coord=ocr_data['y_coord'],
-                width=ocr_data['width'],
-                height=ocr_data['height']
-            )
-            crud.create_ocr_result(db=db, ocr_result=ocr_result_create, document_id=doc_id)
-
-    except KeyError as e:
-        raise HTTPException(status_code=400, detail=f"Missing key in JSON data: {str(e)}")
-    except Exception as e:
-        raise HTTPException(status_code=500, detail=f"Error processing JSON data: {str(e)}")
-
-    return {"message": "JSON processed and OCR results created successfully"}
-
-@app.get("/")
-def read_root():
-    return {"Hello": "World"} 
+app.include_router(documents.router)
+app.include_router(lines.router)

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,0 +1,7 @@
+from .documents import router as documents_router
+from .lines import router as lines_router
+
+__all__ = [
+    "documents_router",
+    "lines_router",
+]

--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -1,0 +1,26 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from backend import schemas
+from backend.services import DocumentService
+from backend.services.dependencies import get_db
+
+router = APIRouter()
+
+@router.post("/documents/", response_model=schemas.Document)
+def create_document(document: schemas.DocumentCreate, db: Session = Depends(get_db)):
+    service = DocumentService(db)
+    return service.create_document(document)
+
+@router.get("/doc/{doc_id}", response_model=schemas.Document)
+def read_document(doc_id: int, db: Session = Depends(get_db)):
+    service = DocumentService(db)
+    return service.get_document(doc_id)
+
+@router.post("/documents/{doc_id}/parse-json")
+def parse_json_for_document(doc_id: int, data: dict, db: Session = Depends(get_db)):
+    service = DocumentService(db)
+    return service.parse_json(doc_id, data)
+
+@router.get("/")
+def read_root():
+    return {"Hello": "World"}

--- a/backend/routers/lines.py
+++ b/backend/routers/lines.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+from backend import schemas
+from backend.services import LineService
+from backend.services.dependencies import get_db
+
+router = APIRouter()
+
+@router.patch("/line/{line_id}", response_model=schemas.LineNumber)
+def update_line(line_id: int, text: str, status: str, db: Session = Depends(get_db)):
+    service = LineService(db)
+    return service.update_line(line_id, text, status)

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,0 +1,7 @@
+from .documents import DocumentService
+from .lines import LineService
+
+__all__ = [
+    "DocumentService",
+    "LineService",
+]

--- a/backend/services/dependencies.py
+++ b/backend/services/dependencies.py
@@ -1,0 +1,8 @@
+from backend.database import SessionLocal
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/services/documents.py
+++ b/backend/services/documents.py
@@ -1,0 +1,30 @@
+from sqlalchemy.orm import Session
+from fastapi import HTTPException
+from backend import crud, schemas
+
+class DocumentService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def create_document(self, document: schemas.DocumentCreate):
+        return crud.create_document(self.db, document)
+
+    def get_document(self, document_id: int):
+        document = crud.get_document(self.db, document_id)
+        if document is None:
+            raise HTTPException(status_code=404, detail="Document not found")
+        return document
+
+    def parse_json(self, doc_id: int, data: dict):
+        self.get_document(doc_id)
+        for ocr_data in data.get("line_numbers", []):
+            ocr_result = schemas.OcrResultCreate(
+                page=ocr_data.get("page", 1),
+                text=ocr_data["text"],
+                x_coord=ocr_data["x_coord"],
+                y_coord=ocr_data["y_coord"],
+                width=ocr_data["width"],
+                height=ocr_data["height"],
+            )
+            crud.create_ocr_result(self.db, ocr_result, document_id=doc_id)
+        return {"message": "JSON processed and OCR results created successfully"}

--- a/backend/services/lines.py
+++ b/backend/services/lines.py
@@ -1,0 +1,13 @@
+from sqlalchemy.orm import Session
+from fastapi import HTTPException
+from backend import crud
+
+class LineService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def update_line(self, line_id: int, text: str, status: str):
+        line = crud.update_line_number(self.db, line_id, text, status)
+        if line is None:
+            raise HTTPException(status_code=404, detail="LineNumber not found")
+        return line

--- a/backend/tests/test_crud.py
+++ b/backend/tests/test_crud.py
@@ -4,7 +4,7 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..',
 
 import pytest
 from backend import crud, schemas
-from backend.models import Document, OcrResult, LineNumber
+from backend.services.documents import DocumentService
 from backend.database import Base
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
@@ -23,24 +23,30 @@ def db_session(db_engine):
     yield session
     session.close()
 
+
 def test_create_and_get_document(db_session):
+    service = DocumentService(db_session)
     doc_data = schemas.DocumentCreate(file_name="test.pdf", pages=1)
-    doc = crud.create_document(db_session, doc_data)
-    fetched = crud.get_document(db_session, doc.id)
+    doc = service.create_document(doc_data)
+    fetched = service.get_document(doc.id)
     assert fetched is not None
     assert fetched.file_name == "test.pdf"
 
+
 def test_create_and_get_ocr_result(db_session):
-    doc = crud.create_document(db_session, schemas.DocumentCreate(file_name="ocr.pdf", pages=1))
+    service = DocumentService(db_session)
+    doc = service.create_document(schemas.DocumentCreate(file_name="ocr.pdf", pages=1))
     ocr_data = schemas.OcrResultCreate(page=1, text="123", x_coord=10, y_coord=20, width=30, height=40)
     ocr = crud.create_ocr_result(db_session, ocr_data, doc.id)
     fetched = crud.get_ocr_result_by_text(db_session, "123", doc.id)
     assert fetched is not None
     assert fetched.text == "123"
 
+
 def test_create_and_get_line_number(db_session):
-    doc = crud.create_document(db_session, schemas.DocumentCreate(file_name="line.pdf", pages=1))
+    service = DocumentService(db_session)
+    doc = service.create_document(schemas.DocumentCreate(file_name="line.pdf", pages=1))
     line_data = schemas.LineNumberCreate(page=1, text="LN-001", x_coord=5, y_coord=5, width=10, height=10)
     line = crud.create_line_number(db_session, line_data, doc.id)
     assert line is not None
-    assert line.text == "LN-001" 
+    assert line.text == "LN-001"

--- a/backend/tests/test_models.py
+++ b/backend/tests/test_models.py
@@ -18,12 +18,14 @@ def db_session(db_engine):
     yield session
     session.close()
 
+
 def test_document_creation(db_session):
     doc = Document(file_name="test.pdf", pages=1)
     db_session.add(doc)
     db_session.commit()
     assert doc.id is not None
     assert doc.file_name == "test.pdf"
+
 
 def test_ocr_result_creation(db_session):
     doc = Document(file_name="test2.pdf", pages=2)
@@ -35,6 +37,7 @@ def test_ocr_result_creation(db_session):
     assert ocr.id is not None
     assert ocr.document_id == doc.id
 
+
 def test_line_number_creation(db_session):
     doc = Document(file_name="test3.pdf", pages=3)
     db_session.add(doc)
@@ -43,4 +46,4 @@ def test_line_number_creation(db_session):
     db_session.add(line)
     db_session.commit()
     assert line.id is not None
-    assert line.document_id == doc.id 
+    assert line.document_id == doc.id

--- a/backend/tests/test_schemas.py
+++ b/backend/tests/test_schemas.py
@@ -6,25 +6,30 @@ import pytest
 from pydantic import ValidationError
 from backend.schemas import DocumentCreate, OcrResultCreate, LineNumberCreate
 
+
 def test_document_create_valid():
     doc = DocumentCreate(file_name="test.pdf", pages=1)
     assert doc.file_name == "test.pdf"
     assert doc.pages == 1
 
+
 def test_document_create_invalid_filename():
     with pytest.raises(ValidationError):
         DocumentCreate(file_name=None, pages=1)
+
 
 def test_ocr_result_create_valid():
     ocr = OcrResultCreate(page=1, text="123", x_coord=10, y_coord=20, width=30, height=40)
     assert ocr.text == "123"
     assert ocr.page == 1
 
+
 def test_ocr_result_negative_coordinates():
     ocr = OcrResultCreate(page=1, text="123", x_coord=-10, y_coord=-20, width=30, height=40)
     assert ocr.x_coord == -10
     assert ocr.y_coord == -20
 
+
 def test_line_number_create_empty_text():
     line = LineNumberCreate(page=1, text=None, x_coord=5, y_coord=5, width=10, height=10)
-    assert line.text is None 
+    assert line.text is None


### PR DESCRIPTION
## Summary
- structure FastAPI code using routers and services
- connect routers in `main.py`
- update tests for new service usage

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685ce0deda4c8322888c30cd0578cd5b