### PR TITLE
Add DB session context manager

### DIFF
--- a/backend/create_document.py
+++ b/backend/create_document.py
@@ -1,28 +1,25 @@
-from backend.database import SessionLocal
+from backend.database import get_session
 from backend import crud, schemas
 
 def create_test_document():
     """
     Creates a test document in the database.
     """
-    db = SessionLocal()
-    print("Creating test document...")
-    
-    try:
-        document_create = schemas.DocumentCreate(
-            file_name="test_pid.pdf",
-            pages=1
-        )
+    with get_session() as db:
+        print("Creating test document...")
         
-        document = crud.create_document(db=db, document=document_create)
-        print(f"Document created successfully with ID: {document.id}")
-        return document.id
-        
-    except Exception as e:
-        print(f"An error occurred: {e}")
-        return None
-    finally:
-        db.close()
-
+        try:
+            document_create = schemas.DocumentCreate(
+                file_name="test_pid.pdf",
+                pages=1
+            )
+            
+            document = crud.create_document(db=db, document=document_create)
+            print(f"Document created successfully with ID: {document.id}")
+            return document.id
+            
+        except Exception as e:
+            print(f"An error occurred: {e}")
+            return None
 if __name__ == "__main__":
     create_test_document() 

--- a/backend/database.py
+++ b/backend/database.py
@@ -15,4 +15,16 @@ engine = create_engine(
 )
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
 
-Base = declarative_base() 
+Base = declarative_base()
+
+from contextlib import contextmanager
+
+
+@contextmanager
+def get_session():
+    """Provide a transactional scope around a series of operations."""
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/backend/parse_vision_json.py
+++ b/backend/parse_vision_json.py
@@ -1,6 +1,6 @@
 import json
 import os
-from backend.database import SessionLocal
+from backend.database import get_session
 from backend import crud, schemas
 
 # The ID of the document we want to import lines for.
@@ -12,103 +12,102 @@ def parse_vision_json_and_import():
     """
     Parses Google Vision API JSON response and imports line numbers.
     """
-    db = SessionLocal()
-    print(f"Starting import for document ID: {DOCUMENT_ID}")
-
-    try:
-        # 1. Delete existing line numbers for the document
-        print(f"Deleting existing line numbers for document ID: {DOCUMENT_ID}...")
-        crud.delete_line_numbers_by_document(db=db, document_id=DOCUMENT_ID)
-        print("Existing line numbers deleted successfully.")
-
-        # 2. Read the JSON file
-        print(f"Reading JSON file from: {JSON_PATH}")
+    with get_session() as db:
+        print(f"Starting import for document ID: {DOCUMENT_ID}")
+    
         try:
-            with open(JSON_PATH, 'r', encoding='utf-8') as f:
-                data = json.load(f)
-        except FileNotFoundError:
-            print(f"Error: JSON file not found at {JSON_PATH}")
-            return
-        except json.JSONDecodeError as e:
-            print(f"Error: Invalid JSON format: {e}")
-            return
-
-        # 3. Extract text blocks from Vision API response
-        line_numbers_data = []
-        
-        if 'responses' in data and len(data['responses']) > 0:
-            response = data['responses'][0]
+            # 1. Delete existing line numbers for the document
+            print(f"Deleting existing line numbers for document ID: {DOCUMENT_ID}...")
+            crud.delete_line_numbers_by_document(db=db, document_id=DOCUMENT_ID)
+            print("Existing line numbers deleted successfully.")
+    
+            # 2. Read the JSON file
+            print(f"Reading JSON file from: {JSON_PATH}")
+            try:
+                with open(JSON_PATH, 'r', encoding='utf-8') as f:
+                    data = json.load(f)
+            except FileNotFoundError:
+                print(f"Error: JSON file not found at {JSON_PATH}")
+                return
+            except json.JSONDecodeError as e:
+                print(f"Error: Invalid JSON format: {e}")
+                return
+    
+            # 3. Extract text blocks from Vision API response
+            line_numbers_data = []
             
-            if 'textAnnotations' in response and len(response['textAnnotations']) > 0:
-                # Skip the first annotation as it contains the full text
-                text_annotations = response['textAnnotations'][1:]
+            if 'responses' in data and len(data['responses']) > 0:
+                response = data['responses'][0]
                 
-                for annotation in text_annotations:
-                    if 'boundingPoly' in annotation and 'vertices' in annotation['boundingPoly']:
-                        vertices = annotation['boundingPoly']['vertices']
-                        
-                        if len(vertices) >= 4:
-                            # Calculate bounding box
-                            x_coords = [v['x'] for v in vertices]
-                            y_coords = [v['y'] for v in vertices]
+                if 'textAnnotations' in response and len(response['textAnnotations']) > 0:
+                    # Skip the first annotation as it contains the full text
+                    text_annotations = response['textAnnotations'][1:]
+                    
+                    for annotation in text_annotations:
+                        if 'boundingPoly' in annotation and 'vertices' in annotation['boundingPoly']:
+                            vertices = annotation['boundingPoly']['vertices']
                             
-                            x_coord = min(x_coords)
-                            y_coord = min(y_coords)
-                            width = max(x_coords) - min(x_coords)
-                            height = max(y_coords) - min(y_coords)
-                            
-                            # Get text content
-                            text = annotation.get('description', '').strip()
-                            
-                            if text:  # Only add if there's actual text
-                                line_numbers_data.append({
-                                    'text': text,
-                                    'x_coord': x_coord,
-                                    'y_coord': y_coord,
-                                    'width': width,
-                                    'height': height
-                                })
-
-        # 4. Create unique line numbers
-        if not line_numbers_data:
-            print("No line numbers found in the JSON file.")
-            return
-
-        unique_lines = set()
-        new_lines_count = 0
-        
-        for line_data in line_numbers_data:
-            # Create a unique identifier for the line based on its text and coordinates
-            line_tuple = (
-                line_data['text'],
-                line_data['x_coord'],
-                line_data['y_coord'],
-                line_data['width'],
-                line_data['height']
-            )
+                            if len(vertices) >= 4:
+                                # Calculate bounding box
+                                x_coords = [v['x'] for v in vertices]
+                                y_coords = [v['y'] for v in vertices]
+                                
+                                x_coord = min(x_coords)
+                                y_coord = min(y_coords)
+                                width = max(x_coords) - min(x_coords)
+                                height = max(y_coords) - min(y_coords)
+                                
+                                # Get text content
+                                text = annotation.get('description', '').strip()
+                                
+                                if text:  # Only add if there's actual text
+                                    line_numbers_data.append({
+                                        'text': text,
+                                        'x_coord': x_coord,
+                                        'y_coord': y_coord,
+                                        'width': width,
+                                        'height': height
+                                    })
+    
+            # 4. Create unique line numbers
+            if not line_numbers_data:
+                print("No line numbers found in the JSON file.")
+                return
+    
+            unique_lines = set()
+            new_lines_count = 0
             
-            if line_tuple not in unique_lines:
-                unique_lines.add(line_tuple)
-                line_create_schema = schemas.LineNumberCreate(
-                    page=1,  # Assuming single page for now
-                    text=line_data['text'],
-                    x_coord=line_data['x_coord'],
-                    y_coord=line_data['y_coord'],
-                    width=line_data['width'],
-                    height=line_data['height']
+            for line_data in line_numbers_data:
+                # Create a unique identifier for the line based on its text and coordinates
+                line_tuple = (
+                    line_data['text'],
+                    line_data['x_coord'],
+                    line_data['y_coord'],
+                    line_data['width'],
+                    line_data['height']
                 )
-                crud.create_line_number(db=db, line_number=line_create_schema, document_id=DOCUMENT_ID)
-                new_lines_count += 1
-
-        print(f"Successfully added {new_lines_count} unique line numbers to document ID: {DOCUMENT_ID}.")
-
-    except Exception as e:
-        print(f"An error occurred during import: {e}")
-        import traceback
-        traceback.print_exc()
-    finally:
-        db.close()
-        print("Database session closed.")
+                
+                if line_tuple not in unique_lines:
+                    unique_lines.add(line_tuple)
+                    line_create_schema = schemas.LineNumberCreate(
+                        page=1,  # Assuming single page for now
+                        text=line_data['text'],
+                        x_coord=line_data['x_coord'],
+                        y_coord=line_data['y_coord'],
+                        width=line_data['width'],
+                        height=line_data['height']
+                    )
+                    crud.create_line_number(db=db, line_number=line_create_schema, document_id=DOCUMENT_ID)
+                    new_lines_count += 1
+    
+            print(f"Successfully added {new_lines_count} unique line numbers to document ID: {DOCUMENT_ID}.")
+    
+        except Exception as e:
+            print(f"An error occurred during import: {e}")
+            import traceback
+            traceback.print_exc()
+        finally:
+            print("Database session closed.")
 
 if __name__ == "__main__":
     parse_vision_json_and_import() 

--- a/backend/populate_line_numbers.py
+++ b/backend/populate_line_numbers.py
@@ -3,15 +3,12 @@ import os
 from sqlalchemy.orm import Session
 
 
-from backend.database import SessionLocal, engine
+from backend.database import get_session
 from backend.parsers import document_ai
 
 def get_db():
-    db = SessionLocal()
-    try:
+    with get_session() as db:
         yield db
-    finally:
-        db.close()
 
 def populate_line_numbers_from_file(db: Session, document_id: int, ground_truth_file: str, ocr_results_file: str):
     """
@@ -36,15 +33,18 @@ def populate_line_numbers_from_file(db: Session, document_id: int, ground_truth_
 
 
 if __name__ == "__main__":
-    db_session = next(get_db())
-    
-    # Assuming document with ID=1 exists from running populate_db.py
-    doc_id = 1
-    
-    # Define paths relative to the project root
-    truth_file = os.path.join('output', 'extracted_piping_lines.txt')
-    ocr_file = os.path.join('data', 'test_pid.pdf_processed.json') # Used for populating ocr_results
+    with get_session() as db_session:
+        # Assuming document with ID=1 exists from running populate_db.py
+        doc_id = 1
 
-    populate_line_numbers_from_file(db=db_session, document_id=doc_id, ground_truth_file=truth_file, ocr_results_file=ocr_file)
-    
-    db_session.close() 
+        # Define paths relative to the project root
+        truth_file = os.path.join('output', 'extracted_piping_lines.txt')
+        ocr_file = os.path.join('data', 'test_pid.pdf_processed.json')  # Used for populating ocr_results
+
+        populate_line_numbers_from_file(
+            db=db_session,
+            document_id=doc_id,
+            ground_truth_file=truth_file,
+            ocr_results_file=ocr_file,
+        )
+

--- a/backend/reimport_lines.py
+++ b/backend/reimport_lines.py
@@ -1,5 +1,5 @@
 import os
-from backend.database import SessionLocal
+from backend.database import get_session
 from backend import crud
 from backend.parsers import document_ai
 
@@ -15,37 +15,36 @@ def reimport_lines_from_db():
     Deletes all existing line numbers for a document and repopulates them
     by filtering the existing OCR results from the database.
     """
-    db = SessionLocal()
-    print(f"Starting line number import from DB for document ID: {DOCUMENT_ID}")
-
-    try:
-        # 1. Delete existing line numbers for the document
-        print(f"Deleting existing line numbers for document ID: {DOCUMENT_ID}...")
-        crud.delete_line_numbers_by_document(db=db, document_id=DOCUMENT_ID)
-        print("Existing line numbers deleted.")
-
-        # 2. Read the target line numbers from the text file
-        print(f"Reading target line numbers from: {TARGET_LINES_PATH}")
+    with get_session() as db:
+        print(f"Starting line number import from DB for document ID: {DOCUMENT_ID}")
+    
         try:
-            with open(TARGET_LINES_PATH, 'r', encoding='utf-8') as f:
-                target_texts = f.readlines()
-        except FileNotFoundError:
-            print(f"Error: Target lines file not found at {TARGET_LINES_PATH}")
-            return
-            
-        if not target_texts:
-            print("No target line numbers found in the file.")
-            return
-
-        # 3. Create line numbers from existing OCR results
-        created = document_ai.create_line_numbers(db, target_texts, DOCUMENT_ID)
-        print(f"Successfully created {created} new line number entries.")
-
-    except Exception as e:
-        print(f"An error occurred during re-import: {e}")
-    finally:
-        db.close()
-        print("Database session closed.")
-
-if __name__ == "__main__":
-    reimport_lines_from_db() 
+            # 1. Delete existing line numbers for the document
+            print(f"Deleting existing line numbers for document ID: {DOCUMENT_ID}...")
+            crud.delete_line_numbers_by_document(db=db, document_id=DOCUMENT_ID)
+            print("Existing line numbers deleted.")
+    
+            # 2. Read the target line numbers from the text file
+            print(f"Reading target line numbers from: {TARGET_LINES_PATH}")
+            try:
+                with open(TARGET_LINES_PATH, 'r', encoding='utf-8') as f:
+                    target_texts = f.readlines()
+            except FileNotFoundError:
+                print(f"Error: Target lines file not found at {TARGET_LINES_PATH}")
+                return
+                
+            if not target_texts:
+                print("No target line numbers found in the file.")
+                return
+    
+            # 3. Create line numbers from existing OCR results
+            created = document_ai.create_line_numbers(db, target_texts, DOCUMENT_ID)
+            print(f"Successfully created {created} new line number entries.")
+    
+        except Exception as e:
+            print(f"An error occurred during re-import: {e}")
+        finally:
+            print("Database session closed.")
+    
+    if __name__ == "__main__":
+        reimport_lines_from_db() 

--- a/backend/run_all_migrations.py
+++ b/backend/run_all_migrations.py
@@ -2,7 +2,7 @@ import json
 import os
 
 from backend import crud, schemas
-from backend.database import SessionLocal
+from backend.database import get_session
 from backend.parsers import document_ai
 
 def parse_and_populate_all():
@@ -15,59 +15,58 @@ def parse_and_populate_all():
     json_path = os.path.join('output', 'test_pid.pdf_processed.json')
     DOCUMENT_ID = 1 # Assuming a single document for this project
 
-    db = SessionLocal()
-    print(f"--- Starting Final Import for Document ID: {DOCUMENT_ID} ---")
-
-    try:
-        # --- Step 1: Ensure Document Exists ---
-        doc = crud.get_document(db, DOCUMENT_ID)
-        if not doc:
-            print(f"Document with ID {DOCUMENT_ID} not found. Creating it.")
-            doc_schema = schemas.DocumentCreate(file_name="test_pid.pdf", pages=1)
-            crud.create_document(db=db, document=doc_schema)
-        else:
-            print(f"Using existing document with ID: {DOCUMENT_ID}")
-        
-        # --- Step 2: Clear Existing Data for a Clean Slate ---
-        print(f"Deleting existing ocr_results for document ID: {DOCUMENT_ID}...")
-        crud.delete_ocr_results_by_document(db=db, document_id=DOCUMENT_ID)
-        print(f"Deleting existing line_numbers for document ID: {DOCUMENT_ID}...")
-        crud.delete_line_numbers_by_document(db=db, document_id=DOCUMENT_ID)
-        print("Existing data cleared.")
-
-        # --- Step 3: Load the Document AI JSON and populate OCR results ---
-        print(f"Loading Document AI JSON from {json_path}...")
+    with get_session() as db:
+        print(f"--- Starting Final Import for Document ID: {DOCUMENT_ID} ---")
+    
         try:
-            doc_ai_data = document_ai.load_json(json_path)
-        except FileNotFoundError:
-            print(f"FATAL: JSON file not found at {json_path}")
-            return
-        except json.JSONDecodeError as e:
-            print(f"FATAL: Invalid JSON format: {e}")
-            return
-        print("JSON loaded successfully.")
-
-        created_count = document_ai.create_ocr_results(db, doc_ai_data, DOCUMENT_ID)
-        print(f"Populated ocr_results table with {created_count} entries.")
-
-        # --- Step 5: Populate line_numbers from ground truth ---
-        print("\nPopulating line_numbers table from ground truth file...")
-        truth_file_path = os.path.join('output', 'extracted_piping_lines.txt')
-        with open(truth_file_path, 'r') as f:
-            target_lines = [line.strip() for line in f.readlines()[4:] if line.strip()]
-
-        lines_created_count = document_ai.create_line_numbers(db, target_lines, DOCUMENT_ID)
-        print(f"Successfully created {lines_created_count} entries in line_numbers table.")
-
-        print("\n--- Import Complete ---")
-
-    except Exception as e:
-        print(f"An error occurred during import: {e}")
-        import traceback
-        traceback.print_exc()
-    finally:
-        db.close()
-        print("Database session closed.")
-
+            # --- Step 1: Ensure Document Exists ---
+            doc = crud.get_document(db, DOCUMENT_ID)
+            if not doc:
+                print(f"Document with ID {DOCUMENT_ID} not found. Creating it.")
+                doc_schema = schemas.DocumentCreate(file_name="test_pid.pdf", pages=1)
+                crud.create_document(db=db, document=doc_schema)
+            else:
+                print(f"Using existing document with ID: {DOCUMENT_ID}")
+            
+            # --- Step 2: Clear Existing Data for a Clean Slate ---
+            print(f"Deleting existing ocr_results for document ID: {DOCUMENT_ID}...")
+            crud.delete_ocr_results_by_document(db=db, document_id=DOCUMENT_ID)
+            print(f"Deleting existing line_numbers for document ID: {DOCUMENT_ID}...")
+            crud.delete_line_numbers_by_document(db=db, document_id=DOCUMENT_ID)
+            print("Existing data cleared.")
+    
+            # --- Step 3: Load the Document AI JSON and populate OCR results ---
+            print(f"Loading Document AI JSON from {json_path}...")
+            try:
+                doc_ai_data = document_ai.load_json(json_path)
+            except FileNotFoundError:
+                print(f"FATAL: JSON file not found at {json_path}")
+                return
+            except json.JSONDecodeError as e:
+                print(f"FATAL: Invalid JSON format: {e}")
+                return
+            print("JSON loaded successfully.")
+    
+            created_count = document_ai.create_ocr_results(db, doc_ai_data, DOCUMENT_ID)
+            print(f"Populated ocr_results table with {created_count} entries.")
+    
+            # --- Step 5: Populate line_numbers from ground truth ---
+            print("\nPopulating line_numbers table from ground truth file...")
+            truth_file_path = os.path.join('output', 'extracted_piping_lines.txt')
+            with open(truth_file_path, 'r') as f:
+                target_lines = [line.strip() for line in f.readlines()[4:] if line.strip()]
+    
+            lines_created_count = document_ai.create_line_numbers(db, target_lines, DOCUMENT_ID)
+            print(f"Successfully created {lines_created_count} entries in line_numbers table.")
+    
+            print("\n--- Import Complete ---")
+    
+        except Exception as e:
+            print(f"An error occurred during import: {e}")
+            import traceback
+            traceback.print_exc()
+        finally:
+            print("Database session closed.")
+    
 if __name__ == "__main__":
-    parse_and_populate_all() 
+parse_and_populate_all() 

--- a/backend/services/dependencies.py
+++ b/backend/services/dependencies.py
@@ -1,8 +1,5 @@
-from backend.database import SessionLocal
+from backend.database import get_session
 
 def get_db():
-    db = SessionLocal()
-    try:
+    with get_session() as db:
         yield db
-    finally:
-        db.close()

--- a/backend/universal_parser.py
+++ b/backend/universal_parser.py
@@ -1,6 +1,6 @@
 import os
 import json
-from backend.database import SessionLocal
+from backend.database import get_session
 from backend import crud, schemas
 from backend.parsers import document_ai
 
@@ -14,53 +14,52 @@ def parse_document_ai_and_import():
     json_path = os.path.join(project_root, 'output', 'test_pid.pdf_processed.json')
     document_filename = "test_pid.pdf"
 
-    db = SessionLocal()
-    
-    try:
-        # 1. Get or create the document
-        print(f"Checking for document: {document_filename}...")
-        db_document = crud.get_document_by_filename(db, filename=document_filename)
-        if not db_document:
-            print("Document not found, creating it...")
-            doc_create = schemas.DocumentCreate(file_name=document_filename, pages=1) # Assuming 1 page for now
-            db_document = crud.create_document(db, document=doc_create)
-            print(f"Document created with ID: {db_document.id}")
-        else:
-            print(f"Document found with ID: {db_document.id}")
-
-        DOCUMENT_ID = db_document.id
-
-        # 2. Delete existing OCR results for the document
-        print(f"Deleting existing OCR results for document ID: {DOCUMENT_ID}...")
-        crud.delete_ocr_results_by_document(db=db, document_id=DOCUMENT_ID)
-        # crud.delete_line_numbers_by_document(db=db, document_id=DOCUMENT_ID) # Old code
-        print("Existing OCR results deleted successfully.")
-
-        # 3. Load the Document AI JSON and import OCR results
-        print(f"Loading Document AI JSON from {json_path}...")
+    with get_session() as db:
+        
         try:
-            doc_ai_data = document_ai.load_json(json_path)
-        except FileNotFoundError:
-            print(f"Error: JSON file not found at {json_path}")
-            return
-        except json.JSONDecodeError as e:
-            print(f"Error: Invalid JSON format: {e}")
-            return
-        print("JSON loaded successfully.")
-
-        print("Importing OCR results into the database...")
-        new_results_count = document_ai.create_ocr_results(db, doc_ai_data, DOCUMENT_ID)
-        print(
-            f"Successfully added {new_results_count} unique OCR results to document ID: {DOCUMENT_ID}."
-        )
-
-    except Exception as e:
-        print(f"An error occurred during import: {e}")
-        import traceback
-        traceback.print_exc()
-    finally:
-        db.close()
-        print("Database session closed.")
+            # 1. Get or create the document
+            print(f"Checking for document: {document_filename}...")
+            db_document = crud.get_document_by_filename(db, filename=document_filename)
+            if not db_document:
+                print("Document not found, creating it...")
+                doc_create = schemas.DocumentCreate(file_name=document_filename, pages=1) # Assuming 1 page for now
+                db_document = crud.create_document(db, document=doc_create)
+                print(f"Document created with ID: {db_document.id}")
+            else:
+                print(f"Document found with ID: {db_document.id}")
+    
+            DOCUMENT_ID = db_document.id
+    
+            # 2. Delete existing OCR results for the document
+            print(f"Deleting existing OCR results for document ID: {DOCUMENT_ID}...")
+            crud.delete_ocr_results_by_document(db=db, document_id=DOCUMENT_ID)
+            # crud.delete_line_numbers_by_document(db=db, document_id=DOCUMENT_ID) # Old code
+            print("Existing OCR results deleted successfully.")
+    
+            # 3. Load the Document AI JSON and import OCR results
+            print(f"Loading Document AI JSON from {json_path}...")
+            try:
+                doc_ai_data = document_ai.load_json(json_path)
+            except FileNotFoundError:
+                print(f"Error: JSON file not found at {json_path}")
+                return
+            except json.JSONDecodeError as e:
+                print(f"Error: Invalid JSON format: {e}")
+                return
+            print("JSON loaded successfully.")
+    
+            print("Importing OCR results into the database...")
+            new_results_count = document_ai.create_ocr_results(db, doc_ai_data, DOCUMENT_ID)
+            print(
+                f"Successfully added {new_results_count} unique OCR results to document ID: {DOCUMENT_ID}."
+            )
+    
+        except Exception as e:
+            print(f"An error occurred during import: {e}")
+            import traceback
+            traceback.print_exc()
+        finally:
+            print("Database session closed.")
 
 def parse_line_numbers():
     """
@@ -72,36 +71,35 @@ def parse_line_numbers():
     lines_txt_path = os.path.join(project_root, 'data', 'extracted_piping_lines.txt')
     DOCUMENT_ID = 1 # Assuming the same document ID
 
-    db = SessionLocal()
-    print("\nStarting line number import process...")
-
-    try:
-        # 1. Clear existing line numbers for the document
-        print(f"Deleting existing line numbers for document ID: {DOCUMENT_ID}...")
-        crud.delete_line_numbers_by_document(db=db, document_id=DOCUMENT_ID)
-        print("Existing line numbers deleted successfully.")
-
-        # 2. Read the list of line numbers to find
-        print(f"Reading line numbers from {lines_txt_path}...")
+    with get_session() as db:
+        print("\nStarting line number import process...")
+    
         try:
-            with open(lines_txt_path, 'r', encoding='utf-8') as f:
-                target_lines = [line.strip() for line in f if line.strip()]
-        except FileNotFoundError:
-            print(f"Error: Lines file not found at {lines_txt_path}")
-            return
-        print(f"Found {len(target_lines)} target line numbers to process.")
-
-        # 3. Create line numbers from OCR results
-        lines_created = document_ai.create_line_numbers(db, target_lines, DOCUMENT_ID)
-        print(f"Successfully created {lines_created} entries in the line_numbers table.")
-
-    except Exception as e:
-        print(f"An error occurred during line number import: {e}")
-        import traceback
-        traceback.print_exc()
-    finally:
-        db.close()
-        print("Database session for line number import closed.")
+            # 1. Clear existing line numbers for the document
+            print(f"Deleting existing line numbers for document ID: {DOCUMENT_ID}...")
+            crud.delete_line_numbers_by_document(db=db, document_id=DOCUMENT_ID)
+            print("Existing line numbers deleted successfully.")
+    
+            # 2. Read the list of line numbers to find
+            print(f"Reading line numbers from {lines_txt_path}...")
+            try:
+                with open(lines_txt_path, 'r', encoding='utf-8') as f:
+                    target_lines = [line.strip() for line in f if line.strip()]
+            except FileNotFoundError:
+                print(f"Error: Lines file not found at {lines_txt_path}")
+                return
+            print(f"Found {len(target_lines)} target line numbers to process.")
+    
+            # 3. Create line numbers from OCR results
+            lines_created = document_ai.create_line_numbers(db, target_lines, DOCUMENT_ID)
+            print(f"Successfully created {lines_created} entries in the line_numbers table.")
+    
+        except Exception as e:
+            print(f"An error occurred during line number import: {e}")
+            import traceback
+            traceback.print_exc()
+        finally:
+            print("Database session for line number import closed.")
 
 if __name__ == "__main__":
     parse_document_ai_and_import()


### PR DESCRIPTION
## Summary
- add `get_session` context manager in `backend/database.py`
- use `get_session` across scripts for database sessions
- update FastAPI dependency to use new manager

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'sqlalchemy')*

------
https://chatgpt.com/codex/tasks/task_e_685d04200adc8322875065265f18d30a