### PR TITLE
Introduce OCR parser base class

### DIFF
--- a/backend/ocr/__init__.py
+++ b/backend/ocr/__init__.py
@@ -1,0 +1,39 @@
+"""OCR parsing utilities and plugin loader."""
+
+from .base import BaseOcrParser
+import importlib
+from importlib import metadata
+
+
+def load_parser(name: str) -> BaseOcrParser:
+    """Load an OCR parser by name.
+
+    The loader first tries to resolve the parser from entry points using the
+    ``pid_visualizer.ocr_parsers`` group. If nothing is found, ``name`` is
+    treated as a module path in ``module:Class`` format.
+    """
+    # Attempt to load from entry points
+    try:
+        eps = metadata.entry_points()
+        if hasattr(eps, "select"):
+            candidates = eps.select(group="pid_visualizer.ocr_parsers")
+        else:  # backward compatibility
+            candidates = eps.get("pid_visualizer.ocr_parsers", [])
+        for ep in candidates:
+            if ep.name == name:
+                parser_cls = ep.load()
+                if not issubclass(parser_cls, BaseOcrParser):
+                    raise TypeError(f"Entry point '{name}' does not provide a BaseOcrParser")
+                return parser_cls()
+    except Exception:
+        pass
+
+    # Fallback: treat name as module[:class]
+    module_path, _, class_name = name.partition(":")
+    mod = importlib.import_module(module_path)
+    parser_cls = getattr(mod, class_name or "Parser")
+    if not issubclass(parser_cls, BaseOcrParser):
+        raise TypeError(f"{parser_cls} is not a BaseOcrParser")
+    return parser_cls()
+
+__all__ = ["BaseOcrParser", "load_parser"]

--- a/backend/ocr/base.py
+++ b/backend/ocr/base.py
@@ -1,0 +1,15 @@
+"""Base classes for OCR parsers."""
+
+from typing import Any
+
+
+class BaseOcrParser:
+    """Abstract OCR parser."""
+
+    def parse(self, file_or_data: Any):
+        """Parse a file path or already loaded data.
+
+        Subclasses must implement this method and return a representation that
+        subsequent processing steps can use.
+        """
+        raise NotImplementedError

--- a/backend/ocr/document_ai.py
+++ b/backend/ocr/document_ai.py
@@ -1,0 +1,95 @@
+"""Parser for Google Document AI JSON output."""
+
+import json
+from typing import Iterable, Any
+from sqlalchemy.orm import Session
+
+from .base import BaseOcrParser
+from backend import crud, schemas
+
+
+class DocumentAiParser(BaseOcrParser):
+    """Parse Google Document AI results."""
+
+    def parse(self, file_or_data: Any) -> dict:
+        """Return Document AI data as a dictionary."""
+        if isinstance(file_or_data, str):
+            with open(file_or_data, "r", encoding="utf-8") as f:
+                return json.load(f)
+        return file_or_data
+
+    def create_ocr_results(self, db: Session, doc_ai_data: dict, document_id: int) -> int:
+        """Parse Document AI JSON and create ``OcrResult`` records.
+
+        Returns the number of created records.
+        """
+        created = 0
+        for page in doc_ai_data.get("pages", []):
+            page_width = page.get("dimension", {}).get("width")
+            page_height = page.get("dimension", {}).get("height")
+            if not page_width or not page_height:
+                continue
+
+            for line in page.get("lines", []):
+                try:
+                    text_anchor = line.get("layout", {}).get("textAnchor", {})
+                    text_segments = text_anchor.get("textSegments", [{}])
+                    start_index = int(text_segments[0].get("startIndex", 0))
+                    end_index = int(text_segments[0].get("endIndex", 0))
+                    text = (
+                        doc_ai_data["text"][start_index:end_index]
+                        .strip()
+                        .replace("\n", " ")
+                    )
+                    vertices = (
+                        line.get("layout", {})
+                        .get("boundingPoly", {})
+                        .get("normalizedVertices", [])
+                    )
+                    if not vertices or not text:
+                        continue
+                    x_coords = [v.get("x", 0) * page_width for v in vertices]
+                    y_coords = [v.get("y", 0) * page_height for v in vertices]
+                    min_x, max_x = min(x_coords), max(x_coords)
+                    min_y, max_y = min(y_coords), max(y_coords)
+                    schema = schemas.OcrResultCreate(
+                        page=page.get("pageNumber", 1),
+                        text=text,
+                        x_coord=min_x,
+                        y_coord=min_y,
+                        width=max_x - min_x,
+                        height=max_y - min_y,
+                    )
+                    crud.create_ocr_result(db=db, ocr_result=schema, document_id=document_id)
+                    created += 1
+                except (KeyError, IndexError, TypeError):
+                    continue
+        return created
+
+    def create_line_numbers(
+        self,
+        db: Session,
+        ground_truth_lines: Iterable[str],
+        document_id: int,
+    ) -> int:
+        """Create ``LineNumber`` records for ``ground_truth_lines`` using existing OCR results."""
+        target_set = {line.strip() for line in ground_truth_lines if line.strip()}
+        if not target_set:
+            return 0
+
+        ocr_results = crud.get_ocr_results(db=db, document_id=document_id)
+        created = 0
+        for result in ocr_results:
+            if result.text in target_set:
+                line_schema = schemas.LineNumberCreate(
+                    page=result.page,
+                    text=result.text,
+                    x_coord=result.x_coord,
+                    y_coord=result.y_coord,
+                    width=result.width,
+                    height=result.height,
+                )
+                crud.create_line_number(db=db, line_number=line_schema, document_id=document_id)
+                created += 1
+        return created
+

--- a/backend/parsers/document_ai.py
+++ b/backend/parsers/document_ai.py
@@ -1,83 +1,19 @@
-import json
-from typing import Iterable, List
+"""Compatibility wrappers around :mod:`backend.ocr.document_ai`."""
+
+from typing import Iterable
 from sqlalchemy.orm import Session
 
-from backend import crud, schemas
+from backend.ocr.document_ai import DocumentAiParser
 
+_parser = DocumentAiParser()
 
-def load_json(json_path: str) -> dict:
-    """Load a Document AI JSON file from ``json_path``."""
-    with open(json_path, 'r', encoding='utf-8') as f:
-        return json.load(f)
+load_json = _parser.parse
+create_ocr_results = _parser.create_ocr_results
+create_line_numbers = _parser.create_line_numbers
 
-
-def create_ocr_results(db: Session, doc_ai_data: dict, document_id: int) -> int:
-    """Parse Document AI JSON and create ``OcrResult`` records.
-
-    Returns the number of created records.
-    """
-    created = 0
-    for page in doc_ai_data.get('pages', []):
-        page_width = page.get('dimension', {}).get('width')
-        page_height = page.get('dimension', {}).get('height')
-        if not page_width or not page_height:
-            continue
-
-        for line in page.get('lines', []):
-            try:
-                text_anchor = line.get('layout', {}).get('textAnchor', {})
-                text_segments = text_anchor.get('textSegments', [{}])
-                start_index = int(text_segments[0].get('startIndex', 0))
-                end_index = int(text_segments[0].get('endIndex', 0))
-                text = (
-                    doc_ai_data['text'][start_index:end_index]
-                    .strip()
-                    .replace('\n', ' ')
-                )
-                vertices = line.get('layout', {}).get('boundingPoly', {}).get('normalizedVertices', [])
-                if not vertices or not text:
-                    continue
-                x_coords = [v.get('x', 0) * page_width for v in vertices]
-                y_coords = [v.get('y', 0) * page_height for v in vertices]
-                min_x, max_x = min(x_coords), max(x_coords)
-                min_y, max_y = min(y_coords), max(y_coords)
-                schema = schemas.OcrResultCreate(
-                    page=page.get('pageNumber', 1),
-                    text=text,
-                    x_coord=min_x,
-                    y_coord=min_y,
-                    width=max_x - min_x,
-                    height=max_y - min_y,
-                )
-                crud.create_ocr_result(db=db, ocr_result=schema, document_id=document_id)
-                created += 1
-            except (KeyError, IndexError, TypeError):
-                continue
-    return created
-
-
-def create_line_numbers(
-    db: Session,
-    ground_truth_lines: Iterable[str],
-    document_id: int,
-) -> int:
-    """Create ``LineNumber`` records for ``ground_truth_lines`` using existing OCR results."""
-    target_set = {line.strip() for line in ground_truth_lines if line.strip()}
-    if not target_set:
-        return 0
-
-    ocr_results = crud.get_ocr_results(db=db, document_id=document_id)
-    created = 0
-    for result in ocr_results:
-        if result.text in target_set:
-            line_schema = schemas.LineNumberCreate(
-                page=result.page,
-                text=result.text,
-                x_coord=result.x_coord,
-                y_coord=result.y_coord,
-                width=result.width,
-                height=result.height,
-            )
-            crud.create_line_number(db=db, line_number=line_schema, document_id=document_id)
-            created += 1
-    return created
+__all__ = [
+    "DocumentAiParser",
+    "load_json",
+    "create_ocr_results",
+    "create_line_numbers",
+]

--- a/backend/populate_line_numbers.py
+++ b/backend/populate_line_numbers.py
@@ -4,7 +4,9 @@ from sqlalchemy.orm import Session
 
 
 from backend.database import get_session
-from backend.parsers import document_ai
+from backend.ocr import load_parser
+
+parser = load_parser("document_ai")
 
 def get_db():
     with get_session() as db:
@@ -28,7 +30,7 @@ def populate_line_numbers_from_file(db: Session, document_id: int, ground_truth_
         return
 
     # 2. Create line number entries from existing OCR results
-    lines_created_count = document_ai.create_line_numbers(db, true_lines, document_id)
+    lines_created_count = parser.create_line_numbers(db, true_lines, document_id)
     print(f"Successfully created {lines_created_count} new entries in the line_numbers table.")
 
 

--- a/backend/reimport_lines.py
+++ b/backend/reimport_lines.py
@@ -1,7 +1,9 @@
 import os
 from backend.database import get_session
 from backend import crud
-from backend.parsers import document_ai
+from backend.ocr import load_parser
+
+parser = load_parser("document_ai")
 
 # The ID of the document we are processing.
 DOCUMENT_ID = 1
@@ -38,7 +40,7 @@ def reimport_lines_from_db():
                 return
     
             # 3. Create line numbers from existing OCR results
-            created = document_ai.create_line_numbers(db, target_texts, DOCUMENT_ID)
+            created = parser.create_line_numbers(db, target_texts, DOCUMENT_ID)
             print(f"Successfully created {created} new line number entries.")
     
         except Exception as e:

--- a/backend/run_all_migrations.py
+++ b/backend/run_all_migrations.py
@@ -3,7 +3,9 @@ import os
 
 from backend import crud, schemas
 from backend.database import get_session
-from backend.parsers import document_ai
+from backend.ocr import load_parser
+
+parser = load_parser("document_ai")
 
 def parse_and_populate_all():
     """
@@ -38,7 +40,7 @@ def parse_and_populate_all():
             # --- Step 3: Load the Document AI JSON and populate OCR results ---
             print(f"Loading Document AI JSON from {json_path}...")
             try:
-                doc_ai_data = document_ai.load_json(json_path)
+                doc_ai_data = parser.parse(json_path)
             except FileNotFoundError:
                 print(f"FATAL: JSON file not found at {json_path}")
                 return
@@ -47,7 +49,7 @@ def parse_and_populate_all():
                 return
             print("JSON loaded successfully.")
     
-            created_count = document_ai.create_ocr_results(db, doc_ai_data, DOCUMENT_ID)
+            created_count = parser.create_ocr_results(db, doc_ai_data, DOCUMENT_ID)
             print(f"Populated ocr_results table with {created_count} entries.")
     
             # --- Step 5: Populate line_numbers from ground truth ---
@@ -56,7 +58,7 @@ def parse_and_populate_all():
             with open(truth_file_path, 'r') as f:
                 target_lines = [line.strip() for line in f.readlines()[4:] if line.strip()]
     
-            lines_created_count = document_ai.create_line_numbers(db, target_lines, DOCUMENT_ID)
+            lines_created_count = parser.create_line_numbers(db, target_lines, DOCUMENT_ID)
             print(f"Successfully created {lines_created_count} entries in line_numbers table.")
     
             print("\n--- Import Complete ---")

--- a/backend/universal_parser.py
+++ b/backend/universal_parser.py
@@ -2,7 +2,9 @@ import os
 import json
 from backend.database import get_session
 from backend import crud, schemas
-from backend.parsers import document_ai
+from backend.ocr import load_parser
+
+parser = load_parser("document_ai")
 
 def parse_document_ai_and_import():
     """
@@ -39,7 +41,7 @@ def parse_document_ai_and_import():
             # 3. Load the Document AI JSON and import OCR results
             print(f"Loading Document AI JSON from {json_path}...")
             try:
-                doc_ai_data = document_ai.load_json(json_path)
+                doc_ai_data = parser.parse(json_path)
             except FileNotFoundError:
                 print(f"Error: JSON file not found at {json_path}")
                 return
@@ -49,7 +51,7 @@ def parse_document_ai_and_import():
             print("JSON loaded successfully.")
     
             print("Importing OCR results into the database...")
-            new_results_count = document_ai.create_ocr_results(db, doc_ai_data, DOCUMENT_ID)
+            new_results_count = parser.create_ocr_results(db, doc_ai_data, DOCUMENT_ID)
             print(
                 f"Successfully added {new_results_count} unique OCR results to document ID: {DOCUMENT_ID}."
             )
@@ -91,7 +93,7 @@ def parse_line_numbers():
             print(f"Found {len(target_lines)} target line numbers to process.")
     
             # 3. Create line numbers from OCR results
-            lines_created = document_ai.create_line_numbers(db, target_lines, DOCUMENT_ID)
+            lines_created = parser.create_line_numbers(db, target_lines, DOCUMENT_ID)
             print(f"Successfully created {lines_created} entries in the line_numbers table.")
     
         except Exception as e:


### PR DESCRIPTION
## Summary
- add `backend/ocr` package with plugin loader
- implement `BaseOcrParser` and `DocumentAiParser`
- update modules to use loader and parser class
- keep backward compatibility wrappers in `backend/parsers/document_ai.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685d0db9d3188322af6fbb3395f17c3c