### PR TITLE
Refactor backend into routers and services

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,25 +1,35 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+
 from backend import models
 from backend.database import engine
-from backend.routers import documents, lines
+from backend.routers import documents_router, lines_router, ocr_router
 
-models.Base.metadata.create_all(bind=engine, checkfirst=True)
 
-app = FastAPI()
+def create_app() -> FastAPI:
+    """Application factory."""
+    models.Base.metadata.create_all(bind=engine, checkfirst=True)
 
-origins = [
-    "http://localhost:5173",
-    "http://127.0.0.1:5173",
-]
+    app = FastAPI()
 
-app.add_middleware(
-    CORSMiddleware,
-    allow_origins=origins,
-    allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
-)
+    origins = [
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
 
-app.include_router(documents.router)
-app.include_router(lines.router)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=origins,
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    app.include_router(documents_router)
+    app.include_router(lines_router)
+    app.include_router(ocr_router)
+
+    return app
+
+
+app = create_app()

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,7 +1,9 @@
 from .documents import router as documents_router
 from .lines import router as lines_router
+from .ocr import router as ocr_router
 
 __all__ = [
     "documents_router",
     "lines_router",
+    "ocr_router",
 ]

--- a/backend/routers/documents.py
+++ b/backend/routers/documents.py
@@ -16,10 +16,6 @@ def read_document(doc_id: int, db: Session = Depends(get_db)):
     service = DocumentService(db)
     return service.get_document(doc_id)
 
-@router.post("/documents/{doc_id}/parse-json")
-def parse_json_for_document(doc_id: int, data: dict, db: Session = Depends(get_db)):
-    service = DocumentService(db)
-    return service.parse_json(doc_id, data)
 
 @router.get("/")
 def read_root():

--- a/backend/routers/ocr.py
+++ b/backend/routers/ocr.py
@@ -1,0 +1,12 @@
+from fastapi import APIRouter, Depends
+from sqlalchemy.orm import Session
+
+from backend.services import OcrService
+from backend.services.dependencies import get_db
+
+router = APIRouter()
+
+@router.post("/documents/{doc_id}/parse-json")
+def parse_json_for_document(doc_id: int, data: dict, db: Session = Depends(get_db)):
+    service = OcrService(db)
+    return service.parse_json(doc_id, data)

--- a/backend/services/__init__.py
+++ b/backend/services/__init__.py
@@ -1,7 +1,9 @@
 from .documents import DocumentService
 from .lines import LineService
+from .ocr import OcrService
 
 __all__ = [
     "DocumentService",
     "LineService",
+    "OcrService",
 ]

--- a/backend/services/documents.py
+++ b/backend/services/documents.py
@@ -15,16 +15,3 @@ class DocumentService:
             raise HTTPException(status_code=404, detail="Document not found")
         return document
 
-    def parse_json(self, doc_id: int, data: dict):
-        self.get_document(doc_id)
-        for ocr_data in data.get("line_numbers", []):
-            ocr_result = schemas.OcrResultCreate(
-                page=ocr_data.get("page", 1),
-                text=ocr_data["text"],
-                x_coord=ocr_data["x_coord"],
-                y_coord=ocr_data["y_coord"],
-                width=ocr_data["width"],
-                height=ocr_data["height"],
-            )
-            crud.create_ocr_result(self.db, ocr_result, document_id=doc_id)
-        return {"message": "JSON processed and OCR results created successfully"}

--- a/backend/services/ocr.py
+++ b/backend/services/ocr.py
@@ -1,0 +1,25 @@
+from sqlalchemy.orm import Session
+from fastapi import HTTPException
+
+from backend import crud, schemas
+
+class OcrService:
+    def __init__(self, db: Session):
+        self.db = db
+
+    def parse_json(self, doc_id: int, data: dict):
+        document = crud.get_document(self.db, doc_id)
+        if document is None:
+            raise HTTPException(status_code=404, detail="Document not found")
+
+        for ocr_data in data.get("line_numbers", []):
+            ocr_result = schemas.OcrResultCreate(
+                page=ocr_data.get("page", 1),
+                text=ocr_data["text"],
+                x_coord=ocr_data["x_coord"],
+                y_coord=ocr_data["y_coord"],
+                width=ocr_data["width"],
+                height=ocr_data["height"],
+            )
+            crud.create_ocr_result(self.db, ocr_result, document_id=doc_id)
+        return {"message": "JSON processed and OCR results created successfully"}


### PR DESCRIPTION
## Summary
- add OCR router and service
- update services package exports
- move JSON parsing logic to `OcrService`
- add `create_app()` factory with CORS middleware and router registration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_685d60a955e48322b1b4acc4ae0e3dcd