### PR TITLE
Add OCR parser configuration and plugin docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,3 +43,18 @@ The repository includes a helper script that monitors the `data` directory and s
 ```bash
 node file-watcher/index.js
 ```
+
+## Extending OCR parsers
+
+OCR parsing is pluggable. The name of the parser is configured via the
+`ocr_parser` option in `backend/config.py` (or the `OCR_PARSER` environment
+variable). Parsers are discovered through the `pid_visualizer.ocr_parsers`
+entry point group. Packages can expose a parser like so:
+
+```ini
+[options.entry_points]
+pid_visualizer.ocr_parsers =
+    custom = myproject.parsers:CustomParser
+```
+
+Install the package and set `OCR_PARSER=custom` to activate it.

--- a/backend/config.py
+++ b/backend/config.py
@@ -9,6 +9,7 @@ class Settings(BaseSettings):
     data_dir: str = "./data"
     debug: bool = False
     log_level: str = "INFO"
+    ocr_parser: str = "document_ai"
     
     # Дополнительные переменные окружения
     google_application_credentials: str = ""

--- a/backend/populate_line_numbers.py
+++ b/backend/populate_line_numbers.py
@@ -5,8 +5,9 @@ from sqlalchemy.orm import Session
 
 from backend.database import get_session
 from backend.ocr import load_parser
+from backend.config import get_settings
 
-parser = load_parser("document_ai")
+parser = load_parser(get_settings().ocr_parser)
 
 def get_db():
     with get_session() as db:

--- a/backend/reimport_lines.py
+++ b/backend/reimport_lines.py
@@ -2,8 +2,9 @@ import os
 from backend.database import get_session
 from backend import crud
 from backend.ocr import load_parser
+from backend.config import get_settings
 
-parser = load_parser("document_ai")
+parser = load_parser(get_settings().ocr_parser)
 
 # The ID of the document we are processing.
 DOCUMENT_ID = 1

--- a/backend/run_all_migrations.py
+++ b/backend/run_all_migrations.py
@@ -4,8 +4,9 @@ import os
 from backend import crud, schemas
 from backend.database import get_session
 from backend.ocr import load_parser
+from backend.config import get_settings
 
-parser = load_parser("document_ai")
+parser = load_parser(get_settings().ocr_parser)
 
 def parse_and_populate_all():
     """

--- a/backend/universal_parser.py
+++ b/backend/universal_parser.py
@@ -3,8 +3,9 @@ import json
 from backend.database import get_session
 from backend import crud, schemas
 from backend.ocr import load_parser
+from backend.config import get_settings
 
-parser = load_parser("document_ai")
+parser = load_parser(get_settings().ocr_parser)
 
 def parse_document_ai_and_import():
     """


### PR DESCRIPTION
## Summary
- add `ocr_parser` setting with default `document_ai`
- load parsers using `get_settings().ocr_parser`
- document plugin mechanism via `pid_visualizer.ocr_parsers` entry points

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e52ea02b08322b66f9d902769e169