### PR TITLE
Add automatic router inclusion

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -3,7 +3,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from backend import models
 from backend.database import engine
-from backend.routers import documents_router, lines_router, ocr_router
+from backend.routers import include_all_routers
 
 
 def create_app() -> FastAPI:
@@ -25,9 +25,7 @@ def create_app() -> FastAPI:
         allow_headers=["*"],
     )
 
-    app.include_router(documents_router)
-    app.include_router(lines_router)
-    app.include_router(ocr_router)
+    include_all_routers(app)
 
     return app
 

--- a/backend/routers/__init__.py
+++ b/backend/routers/__init__.py
@@ -1,3 +1,10 @@
+"""Router package exposing helper to include all routers."""
+
+from importlib import import_module
+import pkgutil
+from fastapi import FastAPI
+
+
 from .documents import router as documents_router
 from .lines import router as lines_router
 from .ocr import router as ocr_router
@@ -6,4 +13,20 @@ __all__ = [
     "documents_router",
     "lines_router",
     "ocr_router",
+    "include_all_routers",
 ]
+
+
+def include_all_routers(app: FastAPI) -> None:
+    """Discover and include all routers in this package.
+
+    Iterates over modules in ``backend.routers`` and, if a module defines a
+    ``router`` attribute, includes it on the given ``FastAPI`` application.
+    """
+
+    package = __name__
+    for _, module_name, _ in pkgutil.iter_modules(__path__):
+        module = import_module(f"{package}.{module_name}")
+        router = getattr(module, "router", None)
+        if router is not None:
+            app.include_router(router)

--- a/backend/tests/test_routers.py
+++ b/backend/tests/test_routers.py
@@ -1,0 +1,33 @@
+import sys
+import os
+from pathlib import Path
+import importlib
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', '..')))
+
+from backend.main import create_app
+
+
+def test_include_all_routers_dynamic_module():
+    routers_dir = Path(__file__).resolve().parent.parent / "routers"
+    temp_module = routers_dir / "temp_router.py"
+    temp_module.write_text(
+        """
+from fastapi import APIRouter
+router = APIRouter()
+@router.get('/temp')
+def read_temp():
+    return {'temp': True}
+"""
+    )
+    try:
+        # Reload routers package to avoid caching
+        import backend.routers
+        importlib.reload(backend.routers)
+        app = create_app()
+        paths = [route.path for route in app.router.routes]
+        assert "/temp" in paths
+    finally:
+        temp_module.unlink()
+        sys.modules.pop("backend.routers.temp_router", None)
+


### PR DESCRIPTION
## Summary
- add `include_all_routers` helper to auto-discover routers
- use `include_all_routers` in `create_app`
- test dynamic router loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ed5b3860832283639e345f9e54a5