### PR TITLE
Add display mode registry

### DIFF
--- a/app/README.md
+++ b/app/README.md
@@ -31,6 +31,29 @@ export default tseslint.config({
 })
 ```
 
+## Registering additional display modes
+
+Services can provide their own display modes by calling
+`registerDisplayMode` during application startup. This populates the internal
+registry used by `DisplayModeSelector` and `UniversalPDFFrame`:
+
+```ts
+import { registerDisplayMode } from './src/utils/overlayUtils';
+
+registerDisplayMode('my_service', {
+  mode: 'my_service',
+  title: 'My Service',
+  description: 'Items from a custom service',
+  defaultColor: '#123456',
+  showGrouping: false,
+  enableSelection: true,
+  enableHover: true,
+});
+```
+
+Call this function once before the main React tree renders so that the new mode
+appears in the selector and is recognized by the PDF frame.
+
 You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
 
 ```js

--- a/app/src/components/DisplayModeSelector.tsx
+++ b/app/src/components/DisplayModeSelector.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { DisplayMode } from '../types/overlay';
-import { DISPLAY_MODE_CONFIGS } from '../utils/overlayUtils';
+import { DISPLAY_MODE_REGISTRY } from '../utils/overlayUtils';
 
 interface DisplayModeSelectorProps {
   currentMode: DisplayMode;
@@ -12,7 +12,7 @@ interface DisplayModeSelectorProps {
 const DisplayModeSelector: React.FC<DisplayModeSelectorProps> = ({
   currentMode,
   onModeChange,
-  availableModes = ['line_numbers', 'ocr_results', 'corrosion_loops', 'equipment', 'clean'],
+  availableModes = Array.from(DISPLAY_MODE_REGISTRY.keys()),
   className = ''
 }) => {
   return (
@@ -22,7 +22,8 @@ const DisplayModeSelector: React.FC<DisplayModeSelectorProps> = ({
       </label>
       <div className="mode-options">
         {availableModes.map((mode) => {
-          const config = DISPLAY_MODE_CONFIGS[mode];
+          const config = DISPLAY_MODE_REGISTRY.get(mode);
+          if (!config) return null;
           return (
             <button
               key={mode}

--- a/app/src/components/UniversalPDFFrame.tsx
+++ b/app/src/components/UniversalPDFFrame.tsx
@@ -9,8 +9,8 @@ import type {
   OverlayEventHandlers, 
   RenderConfig 
 } from '../types/overlay';
-import { 
-  DISPLAY_MODE_CONFIGS,
+import {
+  DISPLAY_MODE_REGISTRY,
   DEFAULT_RENDER_CONFIG,
   filterByPage,
   getGroupItems,
@@ -85,7 +85,7 @@ const UniversalPDFFrame: React.FC<UniversalPDFFrameProps> = ({
   };
 
   // Get display mode configuration
-  const displayConfig = DISPLAY_MODE_CONFIGS[mode];
+  const displayConfig = DISPLAY_MODE_REGISTRY.get(mode);
 
   // Use the pan/zoom hook
   const {
@@ -111,6 +111,11 @@ const UniversalPDFFrame: React.FC<UniversalPDFFrameProps> = ({
     onPanChange,
     onPanningChange,
   });
+
+  if (!displayConfig) {
+    console.warn(`No display mode registered for "${mode}"`);
+    return null;
+  }
 
   // Initialize Fabric.js canvas
   useEffect(() => {

--- a/app/src/utils/overlayUtils.ts
+++ b/app/src/utils/overlayUtils.ts
@@ -71,6 +71,25 @@ export const DISPLAY_MODE_CONFIGS: Record<DisplayMode, DisplayModeConfig> = {
 };
 
 /**
+ * Internal registry for display modes. Initialized with
+ * {@link DISPLAY_MODE_CONFIGS} so that built-in modes are available by
+ * default. New services can register additional modes at runtime.
+ */
+export const DISPLAY_MODE_REGISTRY: Map<DisplayMode, DisplayModeConfig> = new Map(
+  Object.entries(DISPLAY_MODE_CONFIGS) as [DisplayMode, DisplayModeConfig][]
+);
+
+/**
+ * Register a new display mode configuration.
+ *
+ * @param mode - Identifier of the display mode
+ * @param config - Configuration describing behaviour of the mode
+ */
+export function registerDisplayMode(mode: DisplayMode, config: DisplayModeConfig) {
+  DISPLAY_MODE_REGISTRY.set(mode, config);
+}
+
+/**
  * Legacy annotation interface (for backward compatibility)
  */
 interface LegacyAnnotation {


### PR DESCRIPTION
## Summary
- introduce registerDisplayMode and DISPLAY_MODE_REGISTRY
- update DisplayModeSelector & UniversalPDFFrame to use registry
- document registering custom display modes

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860ed61e7e88322904dac566ac9f98a